### PR TITLE
Make desktop and appdata adher slightly better to FDO specs

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -23,7 +23,7 @@ appstream_file = i18n.merge_file(
   output: app_id + '.appdata.xml',
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 icondir = join_paths(get_option('datadir'), 'icons/hicolor/scalable/apps')

--- a/data/org.berarma.Oversteer.desktop.in
+++ b/data/org.berarma.Oversteer.desktop.in
@@ -6,5 +6,5 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Icon=org.berarma.Oversteer
-Categories=Games;Utility;
+Categories=Game;Utility;
 Keywords=game;racing;cars;wheels


### PR DESCRIPTION
Was doing a Gentoo ebuild and got some QA notices on things that didn't quite adher to spec, so here's a PR for improving that.

References;
[Appdata XML should be installed in `/usr/share/metainfo`][1] (And should probably be `.metainfo.xml`, but since `.appdata.xml` is still standard - and not deprecated - I'm not going to change that)
[The desktop category for games is 'Game'][2]

[1]: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location
[2]: https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry