### PR TITLE
Handle missing locales Fixes berarma/oversteer#12

### DIFF
--- a/oversteer/gui.py
+++ b/oversteer/gui.py
@@ -344,7 +344,7 @@ class Gui:
         config_file = os.path.join(self.config_path, 'config.ini')
         with open(config_file, 'w') as file:
             config.write(file)
-                
+
     def stop_button_setup(self):
         self.button_setup_step = False
         self.ui.reset_define_buttons_text()

--- a/oversteer/gui.py
+++ b/oversteer/gui.py
@@ -328,6 +328,14 @@ class Gui:
         self.check_permissions_dialog = self.ui.get_check_permissions()
         check_permissions = '1' if self.check_permissions_dialog else '0'
         config = configparser.ConfigParser()
+        if language != '':
+            try:
+                locale.setlocale(locale.LC_ALL, (language, 'UTF-8'))
+            except locale.Error:
+                self.ui.info_dialog(_("Failed to change language."),
+                _("Make sure locale '" + str(language) + ".UTF8' is generated on your system" ))
+                self.ui.set_language(self.locale)
+                language = self.ui.get_language()
         config['DEFAULT'] = {
             'locale': language,
             'check_permissions': check_permissions,
@@ -336,9 +344,7 @@ class Gui:
         config_file = os.path.join(self.config_path, 'config.ini')
         with open(config_file, 'w') as file:
             config.write(file)
-        if language != '':
-            locale.setlocale(locale.LC_ALL, (language, 'UTF-8'))
-
+                
     def stop_button_setup(self):
         self.button_setup_step = False
         self.ui.reset_define_buttons_text()


### PR DESCRIPTION
Trap error if requested locale missing.
Write config file after attempt to set locale instead of before.
If exception keep the same locale in config file as before.

All a moot point on KDE as locale never changes. Works as expected on openbox.
At least the config file can not now be left in a state where oversteer fails to start. At least I think so.

Fixes berarma/oversteer#12