### PR TITLE
fixed #15

### DIFF
--- a/oversteer/main.css
+++ b/oversteer/main.css
@@ -6,6 +6,8 @@ list.list > row {
     padding-right: 16px;
 }
 levelbar block.filled {
+    min-width: 0px;
+    min-height: 0px;
     background-color: #3584e4;
 }
 stacksidebar list row {


### PR DESCRIPTION
As per request, here is all the code that was needed to fix #15. Also, I believe I might have an explanation for the bug.

Themes are allowed to set their own minimum width on specific objects, and when I went through my theme's gtk.css file, I found out that it sets the default levelbar min-height and min-width to 32px. I suspect your theme doesn't do this, and that autotoxicus's theme does set the values to something other than 0, which is why you can't replicate the bug.