### PR TITLE
Small profile fixes

### DIFF
--- a/oversteer/device.py
+++ b/oversteer/device.py
@@ -171,7 +171,7 @@ class Device:
         with open(path, "r") as file:
             data = file.read()
         autocenter = data.strip()
-        return int(autocenter)
+        return int(round((int(autocenter) * 100) / 65535))
 
     def set_autocenter(self, autocenter):
         autocenter = str(int(65535 * autocenter / 100))

--- a/oversteer/profiles.py
+++ b/oversteer/profiles.py
@@ -5,7 +5,10 @@ class Profile:
     def __init__(self, data = None):
         self.config = configparser.ConfigParser()
         if data is not None:
-            self.import_settings(data)
+            self.import_settings(dict(filter(
+                lambda item: item[1] is not None,
+                data.items()
+            )))
 
     def load(self, profile_file):
         self.config = configparser.ConfigParser()


### PR DESCRIPTION
I've had two issues that I'm trying to address here:
* saving a profile would multiply the autocenter value saved in the profile and shown by the slider in the ui by 655
* being unable to save a profile without installed new-lg4ff (device files for spring, damper, and friction force levels were missing for me and oversteer would fail trying to save `None` values for them into the profile)