### PR TITLE
Added support for T300RS sprind/damper/friction

### DIFF
--- a/data/udev/99-logitech-wheel-perms.rules
+++ b/data/udev/99-logitech-wheel-perms.rules
@@ -44,4 +44,4 @@ SUBSYSTEMS=="hid", KERNELS=="0003:046D:C20E.????", DRIVERS=="logitech", RUN+="/b
 SUBSYSTEMS=="hid", KERNELS=="0003:046D:C202.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'chmod 666 %S%p/../../../range'"
 
 # Thrustmaster T300RS Racing Wheel (USB)
-SUBSYSTEMS=="hid", KERNELS=="0003:044F:B66E.????", DRIVERS=="t300rs", RUN+="/bin/sh -c 'chmod 666 %S%p/../../../range'"
+SUBSYSTEMS=="hid", KERNELS=="0003:044F:B66E.????", DRIVERS=="t300rs", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range spring_level damper_level friction_level'"


### PR DESCRIPTION
I recently added support for changing spring/damper/friction levels in my T300RS driver, and this commit makes Oversteer able to interact with them.