### PR TITLE
meson: add support for installing udev rules to configurable udevrulesdir

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -32,7 +32,8 @@ install_data(app_id + '.svg',
 )
 
 install_subdir('udev',
-  install_dir: pkgdatadir
+  install_dir: udev_rules_dir,
+  strip_directory: true
 )
 
 # ---- Tests ----

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,12 @@ foreach p : python3_required_modules
   endif
 endforeach
 
+udev_rules_dir = get_option('udev_rules_dir')
+if udev_rules_dir == 'auto'
+  udev_dep = dependency('udev')
+  udev_rules_dir = udev_dep.get_pkgconfig_variable('udevdir') + '/rules.d'
+endif
+
 install_subdir('oversteer', install_dir: py_path)
 subdir('data')
 subdir('bin')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,7 @@ option('python',
        description: 'Override the name of the Python executable',
        type: 'string',
        value: 'python3')
+option('udev_rules_dir',
+       description: 'Installation path for udev rules',
+       type: 'string',
+       value: 'auto')


### PR DESCRIPTION
Makes it possible to manually specify a udevrulesdir via meson `-Dudev_rules_dir=/directory`, if no option is passed it introduces a build-time dependency on pkg-config & udev to figure out the correct path to install into automatically.