### PR TITLE
Add Thrustmaster T150 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This software supports the following Logitech wheels:
 
 These other wheels are getting suppport as their drivers mature:
 
+- Thrustmaster T150 with [https://github.com/scarburato/t150_driver].
 - Thrustmaster T300RS with [https://github.com/Kimplul/hid-tmff2].
 - Thrustmaster T500RS with [https://github.com/Kimplul/hid-tmff2].
 - FANATEC CSL Elite Wheel Base with [https://github.com/gotzl/hid-fanatecff].


### PR DESCRIPTION
https://github.com/berarma/oversteer/commit/702f65559b98e8a3e011549c37be0575b0b271ae & https://github.com/berarma/oversteer/commit/74eb614ff0d970110345b23c32ca712307cfcb3e added support for the Thrustmaster T150 but it's missing an entry in README.