### PR TITLE
Add repology badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Oversteer - Steering Wheel Manager for Linux
+# Oversteer - Steering Wheel Manager for Linux [![Packaging status](https://repology.org/badge/tiny-repos/oversteer.svg)](https://repology.org/project/oversteer/versions)
 
 [https://github.com/berarma/oversteer]
 
@@ -56,6 +56,8 @@ with other devices. The Logitech G923 wheel is currently unsupported.
 Use at your own risk. Suggestions, bugs and pull requests welcome.
 
 ## Installation
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/oversteer.svg)](https://repology.org/project/oversteer/versions)
 
 ### Arch
 


### PR DESCRIPTION
Adds two repology badges:
![repology01](https://user-images.githubusercontent.com/414984/120360721-5b5ee600-c309-11eb-9be3-5607749d8843.png)
![repology02](https://user-images.githubusercontent.com/414984/120360763-66b21180-c309-11eb-9e1d-2f30fbdbe33a.png)
See https://repology.org/project/oversteer/badges for more information/options.