### PR TITLE
meson: allow to override the python3 executable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ i18n = import('i18n')
 pymod = import('python')
 prefix = get_option('prefix')
 pkgdatadir = join_paths(prefix, get_option('datadir'), meson.project_name())
-py_installation = pymod.find_installation('python3')
+py_installation = pymod.find_installation(get_option('python'))
 py_path = py_installation.get_path('purelib')
 
 python3_required_modules = ['gi', 'pyudev', 'xdg', 'evdev', 'gettext', 'matplotlib', 'scipy', 'numpy']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('python',
+       description: 'Override the name of the Python executable',
+       type: 'string',
+       value: 'python3')


### PR DESCRIPTION
The reasoning for this is package managers may need to be able to build
the package with a different python version than set system-wide.