### PR TITLE
Added finnish translations

### DIFF
--- a/oversteer/gui.py
+++ b/oversteer/gui.py
@@ -42,6 +42,7 @@ class Gui:
         ('ru_RU', _('Russian')),
         ('es_ES', _('Spanish')),
         ('ca_ES', _('Valencian')),
+        ('fi_FI', _('Finnish')),
     ]
 
     def __init__(self, application, model, argv):

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -2,3 +2,4 @@ ca
 es
 gl
 ru
+fi

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,0 +1,901 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Kim Kuparinen <kimi.h.kuparinen@gmail.com>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-12 17:32+0300\n"
+"PO-Revision-Date: 2021-06-12 18:15+0300\n"
+"Last-Translator: Kim Kuparinen <kimi.h.kuparinen@gmail.com>\n"
+"Language-Team: \n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.2\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: oversteer/application.py:26
+msgid "Oversteer - Steering Wheel Manager"
+msgstr "Oversteer - Rattimanageri"
+
+#: oversteer/application.py:27
+msgid "Run as command's companion"
+msgstr "Suorita komennon apulaisena"
+
+#: oversteer/application.py:28
+msgid "Device path"
+msgstr "Laitepolku"
+
+#: oversteer/application.py:29
+msgid "list connected devices"
+msgstr "luettele yhdistetyt laitteet"
+
+#: oversteer/application.py:30
+msgid "set the compatibility mode"
+msgstr "aseta yhteensopivuustila"
+
+#: oversteer/application.py:31
+msgid "set the rotation range [40-900]"
+msgstr "aseta pyörimiskulma [40-900]"
+
+#: oversteer/application.py:32
+msgid "combine pedals [0-2]"
+msgstr "yhdistä polkimet [0-2]"
+
+#: oversteer/application.py:33
+msgid "set the autocenter strength [0-100]"
+msgstr "aseta keskitysvoima [0-100]"
+
+#: oversteer/application.py:34
+msgid "set the FF gain [0-100]"
+msgstr "aseta efektien voima [0-100]"
+
+#: oversteer/application.py:35
+msgid "set the spring level [0-100]"
+msgstr "aseta jousivoima [0-100]"
+
+#: oversteer/application.py:36
+msgid "set the damper level [0-100]"
+msgstr "aseta vaimennustaso [0-100]"
+
+#: oversteer/application.py:37
+msgid "set the friction level [0-100]"
+msgstr "aseta kitkataso [0-100]"
+
+#: oversteer/application.py:38
+msgid "enable FFBmeter leds"
+msgstr "kytke FFB-mittari -ledivalot päälle"
+
+#: oversteer/application.py:39
+msgid "disable FFBmeter leds"
+msgstr "kytke FFB-mittari -ledivalot pois päältä"
+
+#: oversteer/application.py:40
+msgid "center wheel"
+msgstr "keskitä ratti"
+
+#: oversteer/application.py:41
+msgid "don't center wheel"
+msgstr "älä keskitä rattia"
+
+#: oversteer/application.py:42
+msgid "run command manually"
+msgstr "suorita komento manuaalisesti"
+
+#: oversteer/application.py:44
+msgid "don't run command manually"
+msgstr "älä suorita komentoa manuaalisesti"
+
+#: oversteer/application.py:45
+msgid "load settings from a profile"
+msgstr "lataa asetukset profiilista"
+
+#: oversteer/application.py:46
+msgid "start the GUI"
+msgstr "käynnistä graafinen käyttöliittymä"
+
+#: oversteer/application.py:47
+msgid "enable debug output"
+msgstr "aktivoi debuggaustulostus"
+
+#: oversteer/application.py:48
+msgid "show version"
+msgstr "näytä versio"
+
+#: oversteer/application.py:68
+msgid "Devices found:"
+msgstr "Löytyneet laitteet:"
+
+#: oversteer/application.py:90
+msgid "This profile doesn't exist."
+msgstr "Tätä profiilia ei ole olemassa."
+
+#: oversteer/application.py:100
+msgid "No device available."
+msgstr "Ei laitteita saatavissa."
+
+#: oversteer/gui.py:27
+msgid "Press toggle button/s"
+msgstr "Paina nappeja"
+
+#: oversteer/gui.py:28
+msgid "Press button to set 270°"
+msgstr "Paina nappia asettaaksesi 270°"
+
+#: oversteer/gui.py:29
+msgid "Press button to set 360°"
+msgstr "Paina nappia asettaaksesi 360°"
+
+#: oversteer/gui.py:30
+msgid "Press button to set 540°"
+msgstr "Paina nappia asettaaksesi 540°"
+
+#: oversteer/gui.py:31
+msgid "Press button to set 900°"
+msgstr "Paina nappia asettaaksesi 900°"
+
+#: oversteer/gui.py:32
+msgid "Press button for +10°"
+msgstr "Paina nappia lisätäksesi +10°"
+
+#: oversteer/gui.py:33
+msgid "Press button for -10°"
+msgstr "Paina nappia vähentääksesi -10°"
+
+#: oversteer/gui.py:34
+msgid "Press button for +90°"
+msgstr "Paina nappia lisätäksesi +90°"
+
+#: oversteer/gui.py:35
+msgid "Press button for -90°"
+msgstr "Paina nappia vähentääksesi -90°"
+
+#: oversteer/gui.py:39
+msgid "System default"
+msgstr "Järjestelmän oletusasetus"
+
+#: oversteer/gui.py:40
+msgid "English"
+msgstr "englanti"
+
+#: oversteer/gui.py:41
+msgid "Galician"
+msgstr "galeonkieli"
+
+#: oversteer/gui.py:42
+msgid "Russian"
+msgstr "venäjä"
+
+#: oversteer/gui.py:43
+msgid "Spanish"
+msgstr "espanja"
+
+#: oversteer/gui.py:44
+msgid "Valencian"
+msgstr "valenciankieli"
+
+#: oversteer/gui.py:45
+msgid "Finnish"
+msgstr "suomi"
+
+#: oversteer/gui.py:125
+msgid ""
+"You don't have the required permissions to change your wheel settings. You "
+"can fix it yourself by copying the files in {} to the {} directory and "
+"rebooting."
+msgstr ""
+"Sinulla ei ole tarvittavia oikeuksia muuttaa rattiasetuksia.Voit korjata "
+"tilanteen itse kopioimalla kaikki tiedostot kansiosta {} kansioon {} ja "
+"käynnistämällä tietokoneen uudelleen."
+
+#: oversteer/gui.py:129
+msgid "Do you want us to make this change for you?"
+msgstr "Haluatko tämän muutoksen tehdyksi automaattisesti?"
+
+#: oversteer/gui.py:142
+msgid "Permissions rules installed."
+msgstr "Lupa-asetukset asennettu."
+
+#: oversteer/gui.py:143
+msgid "In some cases, a system restart might be needed."
+msgstr "Joissakin tapauksissa järjestelmän uudelleenkäynnistys on tarpeen."
+
+#: oversteer/gui.py:145
+msgid ""
+"Error installing permissions rules. Please, try again and make sure you use "
+"the right password for the administrator user."
+msgstr ""
+"Virhe lupa-asetuksia asennettaessa. Ystävällisesti yritä uudelleen, ja "
+"varmista, että käytät oikeaa salasanaa."
+
+#: oversteer/gui.py:198
+msgid "Error opening profile"
+msgstr "Virhe profiilia avattaessa"
+
+#: oversteer/gui.py:198
+msgid "The selected profile can't be loaded."
+msgstr "Valittua profiilia ei voida ladata."
+
+#: oversteer/gui.py:213
+msgid "This profile already exists. Are you sure?"
+msgstr "Tämä profiili on jo olemassa. Oletko varma?"
+
+#: oversteer/gui.py:225
+msgid "This profile will be deleted, are you sure?"
+msgstr "Tämä profiili poistetaan, oletko varma?"
+
+#: oversteer/gui.py:232
+msgid "Invalid extension."
+msgstr "Epäkelpo tiedostopääte."
+
+#: oversteer/gui.py:236
+msgid "A profile with that name already exists."
+msgstr "Profiili tuolla nimellä on jo olemassa."
+
+#: oversteer/gui.py:243
+msgid "File already exists, overwrite?"
+msgstr "Tiedosto on jo olemassa, kirjoita päälle?"
+
+#: oversteer/gui.py:275
+msgid "Failed to change language"
+msgstr "Kielen vaihto epäonnistui"
+
+#: oversteer/gui.py:276
+msgid "Make sure locale '{}.UTF8' is generated on your system."
+msgstr "Varmista, että lokaali '{}.UTF8' on asennettuna."
+
+#: oversteer/gui.py:453
+msgid "Command error"
+msgstr "Komentovirhe"
+
+#: oversteer/gui.py:454
+msgid ""
+"The supplied command failed:\n"
+"{}"
+msgstr ""
+"Annettu komento epäonnistui\n"
+"{}"
+
+#: oversteer/gui.py:479
+msgid "Steering wheel not responding."
+msgstr "Ratti ei vastaa."
+
+#: oversteer/gui.py:479
+msgid "No wheel movement could be registered."
+msgstr "Ratin liikettä ei voitu havaita."
+
+#: oversteer/gui.py:522
+msgid "CSV file to import"
+msgstr "Ladattava CSV-tiedosto"
+
+#: oversteer/gui.py:556
+msgid "Test data imported."
+msgstr "Testidata ladattu."
+
+#: oversteer/gui.py:557
+msgid "New test data imported from CSV file."
+msgstr "Uutta testidataa ladattu CSV-tiedostosta."
+
+#: oversteer/gui.py:564
+msgid "CSV file to export"
+msgstr "Tallennettava CSV-tiedosto"
+
+#: oversteer/gui.py:578
+msgid "Test data exported."
+msgstr "Testidata tallennettu."
+
+#: oversteer/gui.py:579
+msgid "Current test data has been exported to a CSV file."
+msgstr "Testidata tallennettu CSV-tiedostoon."
+
+#: oversteer/main.ui:41
+msgid "Preferences"
+msgstr "Asetukset"
+
+#: oversteer/main.ui:66
+msgid "About Oversteer"
+msgstr "Tietoja"
+
+#: oversteer/main.ui:234 data/org.berarma.Oversteer.desktop.in:3
+msgid "Oversteer"
+msgstr "Oversteer"
+
+#: oversteer/main.ui:291
+msgid "Speed test"
+msgstr "Nopeustesti"
+
+#: oversteer/main.ui:295
+msgid "Curve test"
+msgstr "Kaarretesti"
+
+#: oversteer/main.ui:329
+msgid "Select the wheel controller you want to configure."
+msgstr "Valitse minkä ratin asetuksia haluat muokata."
+
+#: oversteer/main.ui:336
+msgid "Device"
+msgstr "Laite"
+
+#: oversteer/main.ui:370
+msgid "Select a profile to load the saved settings."
+msgstr "Valitse profiili, jonka asetukset ladataan."
+
+#: oversteer/main.ui:390
+msgid "Save"
+msgstr "Tallenna"
+
+#: oversteer/main.ui:394
+msgid "Save profile"
+msgstr "Tallenna profiili"
+
+#: oversteer/main.ui:422
+msgid "Profile"
+msgstr "Profiili"
+
+#: oversteer/main.ui:478
+msgid "Select an emulation mode from the ones supported."
+msgstr "Valitse emulaatiotila tuetuista vaihtoehdoista."
+
+#: oversteer/main.ui:486
+msgid "Compatibility mode"
+msgstr "Yhteensopivuustila"
+
+#: oversteer/main.ui:512
+msgid "Apply"
+msgstr "Aseta"
+
+#: oversteer/main.ui:516
+msgid "Apply changes (the wheel may move when changing the emulation mode)."
+msgstr "Aseta muutokset (ratti saattaa liikahtaa emulaatiotilaa muuttaessa)"
+
+#: oversteer/main.ui:550
+msgid ""
+"Range in degrees that the wheel will be able to rotate both ways. It will "
+"affect the sensitivity."
+msgstr ""
+"Väli, jonka sisällä ratti voi pyöriä molempiin suuntiin. Vaikuttaa ratin "
+"herkkyyteen."
+
+#: oversteer/main.ui:558
+msgid "Rotation range"
+msgstr "Pyörimisväli"
+
+#: oversteer/main.ui:611
+msgid ""
+"Combine two pedals into one axe. Useful for old games and flight simulators."
+msgstr ""
+"Yhdistä kaksi poljinta yhteen akseliin. Käytevää vanhoissa peleissä ja "
+"lentosimulaattoreissa."
+
+#: oversteer/main.ui:619
+msgid "Combine pedals"
+msgstr "Yhdistä polkimet"
+
+#: oversteer/main.ui:633
+msgid "Accelerator + Clutch"
+msgstr "Kaasu + Kytkin"
+
+#: oversteer/main.ui:649
+msgid "Accelerator + Brakes"
+msgstr "Kaasu + Jarru"
+
+#: oversteer/main.ui:665
+msgid "None"
+msgstr "Ei mikään"
+
+#: oversteer/main.ui:723
+msgid "Steering"
+msgstr "Ohjaus"
+
+#: oversteer/main.ui:806
+msgid "Clutch"
+msgstr "Kytkin"
+
+#: oversteer/main.ui:833
+msgid "Brakes"
+msgstr "Jarru"
+
+#: oversteer/main.ui:860
+msgid "Accel."
+msgstr "Kaasu"
+
+#: oversteer/main.ui:884
+msgid "Hat"
+msgstr "Hattu"
+
+#: oversteer/main.ui:1024
+msgid "Buttons"
+msgstr "Napit"
+
+#: oversteer/main.ui:1767
+msgid "Controls"
+msgstr "Ohjaus"
+
+#: oversteer/main.ui:1801
+msgid "Global strength for all force feedback effects."
+msgstr "Yleisvoima kaikille efekteille."
+
+#: oversteer/main.ui:1809
+msgid "Global feedback gain"
+msgstr "Yleisvoiman suuruus"
+
+#: oversteer/main.ui:1850
+msgid ""
+"Gain applied to spring effects. Higher values may produce more clipping."
+msgstr ""
+"Jousiefekteihin sovellettu suuruus. Suuremmat arvot saattavat aiheuttaa "
+"enemmän leikkaantumista."
+
+#: oversteer/main.ui:1858
+msgid "Spring effect gain"
+msgstr "Jousivoiman suuruus"
+
+#: oversteer/main.ui:1899
+msgid ""
+"Gain applied to damper effects. Higher values may produce more clipping."
+msgstr ""
+"Vaimennusefekteihin sovellettu suuruus. Suuremmat arvot saattavat aiheuttaa "
+"enemmän leikkaantumista."
+
+#: oversteer/main.ui:1907
+msgid "Damper effect gain"
+msgstr "Vaimennuksen suuruus"
+
+#: oversteer/main.ui:1949
+msgid ""
+"Gain applied to friction effects. Higher values may produce more clipping."
+msgstr ""
+"Kitkaefekteihin sovellettu suuruus. Suuremmat arvot saattavat aiheuttaa "
+"enemmän leikkaantumista."
+
+#: oversteer/main.ui:1957
+msgid "Friction effect gain"
+msgstr "Kitkaefektin suuruus"
+
+#: oversteer/main.ui:2010
+msgid "Continuous autocenter force strength."
+msgstr "Jatkuvan keskitysvoiman suuruus."
+
+#: oversteer/main.ui:2018
+msgid "Autocenter strength"
+msgstr "Keskitysvoiman suuruus"
+
+#: oversteer/main.ui:2067
+msgid "Force Feedback"
+msgstr "Värinä"
+
+#: oversteer/main.ui:2098
+msgid ""
+"Center the wheel immediately after this option is enabled. Works also when "
+"setting it from a profile."
+msgstr ""
+"Keskitä ratti heti tämän asetuksen päälle laittamisen jälkeen. Toimii myös "
+"profiileissa."
+
+#: oversteer/main.ui:2106
+msgid "Center wheel"
+msgstr "Keskitä ratti"
+
+#: oversteer/main.ui:2141
+msgid "Start the companion application manually from the GUI."
+msgstr "Suorita sovellus manuaalisesti graafisesta käyttöliittymästä."
+
+#: oversteer/main.ui:2149
+msgid "Start application manually"
+msgstr "Suorita sovellus manuaalisesti"
+
+#: oversteer/main.ui:2185
+msgid ""
+"Enable wheel range settings in the window overlay. When set to auto, it will "
+"be displayed only when being set using the wheel buttons."
+msgstr ""
+"Kytke ratin kääntösäteen asetukset päälle ikkunapäällysteessä. Kun auto on "
+"valittuna, päällyste näkyy vain kääntösädenappeja painettaessa."
+
+#: oversteer/main.ui:2193
+msgid "Wheel range display"
+msgstr "Kääntösädenäkymä"
+
+#: oversteer/main.ui:2207
+msgid "Auto"
+msgstr "Auto"
+
+#: oversteer/main.ui:2223
+msgid "Always"
+msgstr "Aina"
+
+#: oversteer/main.ui:2239
+msgid "Never"
+msgstr "Ei koskaan"
+
+#: oversteer/main.ui:2278
+msgid "Enable FFBmeter using the leds in the wheel or the window overlay."
+msgstr "Näytä FFB-mittari ratin ledien tai ikkunapäällysteen avulla."
+
+#: oversteer/main.ui:2286
+msgid "FFBmeter"
+msgstr "FFB-mittari"
+
+#: oversteer/main.ui:2300
+msgid "Leds"
+msgstr "Ledit"
+
+#: oversteer/main.ui:2314
+msgid "Overlay"
+msgstr "Päällyste"
+
+#: oversteer/main.ui:2351
+msgid ""
+"Use wheel buttons to control some wheel settings. The buttons must be "
+"defined in the preferences window."
+msgstr ""
+"Käytä ratin nappeja joidenkin asetusten säätämiseen. Napit pitää valita "
+"asetukset-ikkunasta."
+
+#: oversteer/main.ui:2359
+msgid "Enable wheel buttons"
+msgstr "Käytä ratin nappeja"
+
+#: oversteer/main.ui:2402
+msgid "Tools"
+msgstr "Työkalut"
+
+#: oversteer/main.ui:2427
+msgid "Start new"
+msgstr "Aloita uudestaan"
+
+#: oversteer/main.ui:2441
+msgid "Import CSV"
+msgstr "Lataa CSV"
+
+#: oversteer/main.ui:2455
+msgid "Export CSV"
+msgstr "Tallenna CSV"
+
+#: oversteer/main.ui:2469
+msgid "Open chart"
+msgstr "Avaa kuvaaja"
+
+#: oversteer/main.ui:2504
+msgid ""
+"No test data available. Please, import test data or start a new test.\n"
+"Be careful when running the tests and follow the instructions as closely as "
+"possible for safety and valid results."
+msgstr ""
+"Testidataa ei saatavilla. Lataa testidataa tai aloita uusi testi.\n"
+"Ole varovainen testiä ajettaessa ja seuraa ohjeita mahdollisimman tarkkaan "
+"turvallisuuden ja tarkempien tulosten varmistamiseksi."
+
+#: oversteer/main.ui:2519
+msgid "page1"
+msgstr "sivu1"
+
+#: oversteer/main.ui:2531
+msgid ""
+"The lowest torque test measures the minimum force level that the wheel can "
+"deliver. Your help is required for this test."
+msgstr ""
+"Pienin vääntömomentti -testi mittaa pienimmän voimatason mitä ratti pystyy "
+"tuottamaan. Apuasi tarvitaan tätä testiä varten."
+
+#: oversteer/main.ui:2545
+msgid "page2"
+msgstr "sivu2"
+
+#: oversteer/main.ui:2558
+msgid "The linearity test measures the linear force response."
+msgstr "Lineaarisuustesti mittaa lineaarisen voiman responssia."
+
+#: oversteer/main.ui:2571
+msgid "page5"
+msgstr "sivu5"
+
+#: oversteer/main.ui:2584
+msgid ""
+"The step test measures several performance parameters at the highest force "
+"levels."
+msgstr ""
+"Askeltesti mittaa monia suoritusparametreja suurimmilla mahdollisilla "
+"voimatasoilla."
+
+#: oversteer/main.ui:2597
+msgid "page3"
+msgstr "sivu3"
+
+#: oversteer/main.ui:2610
+msgid "The test is running, please, don't touch the wheel and wait."
+msgstr "Testiä suoritetaan, odota äläkä koske rattiin."
+
+#: oversteer/main.ui:2624
+msgid "page4"
+msgstr "sivu4"
+
+#: oversteer/main.ui:2650
+msgid "Max. angular acceleration (RPM/s):"
+msgstr "Suurin ratakiihtyvyys (RPM/s):"
+
+#: oversteer/main.ui:2665
+msgid "Max. angular deceleration (RPM/s):"
+msgstr "Suurin ratahidastus (RPM/s):"
+
+#: oversteer/main.ui:2680
+msgid "Mean angular acceleration (RPM/s):"
+msgstr "Ratakiihtyvyyden keskiarvo (RPM/s):"
+
+#: oversteer/main.ui:2695
+msgid "Residual angular deceleration (RPM/s):"
+msgstr "Jälkiratahidastus (RPM/s):"
+
+#: oversteer/main.ui:2710
+msgid "Latency (ms):"
+msgstr "Viive (ms):"
+
+#: oversteer/main.ui:2725
+msgid "Min. force level (%):"
+msgstr "Pienin voimataso (%):"
+
+#: oversteer/main.ui:2805
+msgid "Max. angular velocity (RPM):"
+msgstr "Suurin ratanopeus (RPM):"
+
+#: oversteer/main.ui:2820
+msgid "Mean angular deceleration (RPM/s):"
+msgstr "Ratahidastuksen keskiarvo (RPM/s):"
+
+#: oversteer/main.ui:2835
+msgid "Time to max. angular acceleration (ms):"
+msgstr "Aika suurimpaan ratakiihtyvyyteen (ms):"
+
+#: oversteer/main.ui:2850
+msgid "Time to max. angular deceleration (ms):"
+msgstr "Aika suurimpaan ratahidastukseen (ms):"
+
+#: oversteer/main.ui:2865
+msgid "Estimated SNR (dB):"
+msgstr "Arvioitu SNR (dB):"
+
+#: oversteer/main.ui:2973
+msgid "page0"
+msgstr "sivu0"
+
+#: oversteer/main.ui:2986
+msgid ""
+"For the duration of this test you have to hold your steering wheel firmly in "
+"your hands and move it slowly around its middle position. When you notice a "
+"slight resistance or pulsation press any button in the wheel."
+msgstr ""
+"Tämän testin ajan ratista pitää pitää kiinni ja hitaasti liikuttaa sitä sen "
+"keskipisteen ympäri. Kun tunnet pientä vastusta tai tärinää, paina mitä "
+"tahansa ratin nappia."
+
+#: oversteer/main.ui:3001
+msgid "Press any wheel button when ready to start the test."
+msgstr "Paina mitä tahansa ratin nappia testin aloittamiseksi."
+
+#: oversteer/main.ui:3015
+msgid "Now running the test."
+msgstr "Testejä suoritetaan."
+
+#: oversteer/main.ui:3028
+msgid "page6"
+msgstr "sivu6"
+
+#: oversteer/main.ui:3043
+msgid ""
+"WARNING: Don't touch the wheel and leave a clear space around it to avoid "
+"accidents or unreliable results."
+msgstr ""
+"VAROITUS: Älä koske rattiin ja jätä sen ympärille tilaa välttyäksesi "
+"vahingoilta ja/tai epäluotettavilta tuloksilta."
+
+#: oversteer/main.ui:3065
+msgid "Back"
+msgstr "Takaisin"
+
+#: oversteer/main.ui:3079
+msgid "Run"
+msgstr "Suorita"
+
+#: oversteer/main.ui:3113
+msgid "Tests"
+msgstr "Testit"
+
+#: oversteer/main.ui:3192
+msgid "New"
+msgstr "Uusi"
+
+#: oversteer/main.ui:3206
+msgid "Rename"
+msgstr "Nimeä uudelleen"
+
+#: oversteer/main.ui:3220
+msgid "Delete"
+msgstr "Poista"
+
+#: oversteer/main.ui:3234
+msgid "Import"
+msgstr "Tuo"
+
+#: oversteer/main.ui:3248
+msgid "Export"
+msgstr "Vie"
+
+#: oversteer/main.ui:3276
+msgid "Profiles"
+msgstr "Profiilit"
+
+#: oversteer/main.ui:3292
+msgid "Start Application"
+msgstr "Käynnistä sovellus"
+
+#: oversteer/main.ui:3343
+msgid "Re-scan wheel devices and update window."
+msgstr "Etsi ratteja ja päivitä ikkuna."
+
+#: oversteer/main.ui:3403
+msgid "Oversteer preferences"
+msgstr "Oversteer asetukset"
+
+#: oversteer/main.ui:3433
+msgid ""
+"Check permissions to read/write device settings and propose changes to make "
+"them available to normal users."
+msgstr ""
+"Tarkista laitteen luku- ja kirjoitusoikeudet ja esitä muutoksia tavallisille "
+"käyttäjille."
+
+#: oversteer/main.ui:3441
+msgid "Check permissions"
+msgstr "Tarkista oikeudet"
+
+#: oversteer/main.ui:3473
+msgid ""
+"Change the interface language. You'll need to restart the application to "
+"apply."
+msgstr ""
+"Muuta käyttöliittymän kieltä. Joudut käynnistämään sovelluksen uudestaan."
+
+#: oversteer/main.ui:3481
+msgid "Language"
+msgstr "Kieli"
+
+#: oversteer/main.ui:3512
+msgid ""
+"Pressing start will begin configuration of wheel buttons. Just press the "
+"button in the wheel that you want to use for every displayed action."
+msgstr ""
+"Käynnistä-nappi konfiguroi ratin napit. Paina ratin nappia, jonka haluat "
+"suorittavan näytetyn teon."
+
+#: oversteer/main.ui:3518
+msgid "Define buttons"
+msgstr "Määrittele napit"
+
+#: oversteer/main.ui:3528
+msgid "Start"
+msgstr "Käynnistä"
+
+#: oversteer/combined_chart.py:15
+msgid "Linear response test"
+msgstr "Lineaarivastetesti"
+
+#: oversteer/combined_chart.py:16 oversteer/combined_chart.py:25
+msgid "Input force"
+msgstr "Sisääntulovoima"
+
+#: oversteer/combined_chart.py:17
+msgid "Output force"
+msgstr "Ulostulovoima"
+
+#: oversteer/combined_chart.py:18
+msgid "Force level"
+msgstr "Voimataso"
+
+#: oversteer/combined_chart.py:24
+msgid "Step test (angular velocity + position)"
+msgstr "Askeltesti (ratanopeus + sijainti)"
+
+#: oversteer/combined_chart.py:26
+msgid "Angular displacement (raw)"
+msgstr "Kulmasiirtymä (raaka)"
+
+#: oversteer/combined_chart.py:27
+msgid "Angular displacement (smoothed)"
+msgstr "Kulmasiirtymä (tasattu)"
+
+#: oversteer/combined_chart.py:28
+msgid "Angular velocity (raw)"
+msgstr "Kulmanopeus (raaka)"
+
+#: oversteer/combined_chart.py:29
+msgid "Angular velocity (smoothed)"
+msgstr "Kulmanopeus (tasattu)"
+
+#: oversteer/combined_chart.py:30 oversteer/combined_chart.py:42
+msgid "Time (s)"
+msgstr "Aika (s)"
+
+#: oversteer/combined_chart.py:31
+msgid "Position"
+msgstr "Sijainti"
+
+#: oversteer/combined_chart.py:32
+msgid "RPM"
+msgstr "RPM"
+
+#: oversteer/combined_chart.py:38
+msgid "Step test (angular acceleration)"
+msgstr "Askeltesti (kulmakiihtyvyys)"
+
+#: oversteer/combined_chart.py:39
+msgid "Input Force"
+msgstr "Sisääntulovoima"
+
+#: oversteer/combined_chart.py:40
+msgid "Angular acceleration (raw)"
+msgstr "Kulmakiihtyvyys (raaka)"
+
+#: oversteer/combined_chart.py:41
+msgid "Angular acceleration (smoothed)"
+msgstr "Kulmakiihtyvyys (tasattu)"
+
+#: oversteer/combined_chart.py:43
+msgid "RPM/s"
+msgstr "RPM/s"
+
+#: oversteer/combined_chart.py:49
+msgid "Latency = {:.0f} ms"
+msgstr "Viive = {:.0f} ms"
+
+#: oversteer/combined_chart.py:50
+msgid "Max. velocity = {:.0f} RPM"
+msgstr "Suur. nopeus = {:.0f} RPM"
+
+#: oversteer/combined_chart.py:51
+msgid "Mean accel. = {:.0f} RPM/s"
+msgstr "Keskinopeus = {:.0f} RPM/s"
+
+#: oversteer/combined_chart.py:52
+msgid "Mean decel. = {:.0f} RPM/s"
+msgstr "Keskihidastus = {:.0f} RPM/s"
+
+#: oversteer/combined_chart.py:53
+msgid "Max. accel. = {:.0f} RPM/s"
+msgstr "Suur. kiiht. = {:.0f} RPM/s"
+
+#: oversteer/combined_chart.py:54
+msgid "Time max. accel. = {:.0f} ms"
+msgstr "Aika suur. kiiht. = {:.0f} ms"
+
+#: oversteer/combined_chart.py:55
+msgid "Max. decel. = {:.0f} RPM/s"
+msgstr "Suur. hidast. = {:.0f} RPM/s"
+
+#: oversteer/combined_chart.py:56
+msgid "Time max. decel. = {:.0f} ms"
+msgstr "Aika suur. hidast. = {:.0f} ms"
+
+#: oversteer/combined_chart.py:57
+msgid "Residual decel. = {:.0f} RPM/s"
+msgstr "Jälkihidastus = {:.0f} RPM/s"
+
+#: oversteer/combined_chart.py:58
+msgid "Estimated SNR = {:.0f} dB"
+msgstr "Arvioitu SNR = {:.0f} dB"
+
+#: oversteer/combined_chart.py:59
+msgid "Min. force level = {:.1f} %"
+msgstr "Pienin voimataso = {:.1f} %"
+
+#: data/org.berarma.Oversteer.desktop.in:4
+msgid "Steering Wheel Manager"
+msgstr "Rattimanageri"
+
+#: data/org.berarma.Oversteer.desktop.in:12
+msgid "game;racing;cars;wheels"
+msgstr "peli;ajo;autot;ratit"


### PR DESCRIPTION
Not a translator by trade, so some translations might be _slightly_ off.

Some notes:
+ In Finnish, languages are written with small letters. Some translation programs may complain about this.
+ In Finnish, there isn't really a good translation for `Rename`. The closest would be `Nimeä uudelleen`, but even if I shorten it I still end up with this somewhat ugly view: 
 
![image](https://user-images.githubusercontent.com/26362752/121781292-b5cf3080-cbac-11eb-8df1-3aedd733facb.png)
