### PR TITLE
use newer tmff2 driver with t300rs

### DIFF
--- a/data/udev/99-thrustmaster-wheel-perms.rules
+++ b/data/udev/99-thrustmaster-wheel-perms.rules
@@ -8,7 +8,7 @@
 SUBSYSTEMS=="hid", KERNELS=="0003:044F:B65E.????", DRIVERS=="t500rs", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range spring_level damper_level friction_level'"
 
 # Thrustmaster T300RS Racing Wheel (USB)
-SUBSYSTEMS=="hid", KERNELS=="0003:044F:B66E.????", DRIVERS=="t300rs", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range spring_level damper_level friction_level'"
+SUBSYSTEMS=="hid", KERNELS=="0003:044F:B66E.????", DRIVERS=="tmff2", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range spring_level damper_level friction_level alternate_modes'"
 
 # Thrustmaster T248 Racing Wheel (USB)
 SUBSYSTEMS=="hid", KERNELS=="0003:044F:B696.????", DRIVERS=="tmff2", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range spring_level damper_level friction_level'"


### PR DESCRIPTION
Allow for modesetting, as discussed in #97. This patch only allows for the newer driver name, `tmff2`, which might break for some users who still have the older module version installed. This can be worked around by keeping the line with `DRIVERS={t300rs}` around, but I'd prefer people moved over to the newer version whenever possible.