### PR TITLE
Add option to change pedal axis behavior

### DIFF
--- a/oversteer/gtk_handlers.py
+++ b/oversteer/gtk_handlers.py
@@ -82,12 +82,15 @@ class GtkHandlers:
 
     def on_combine_none_clicked(self, widget):
         self.model.set_combine_pedals(0)
+        self.ui.set_pedal_levels()
 
     def on_combine_brakes_clicked(self, widget):
         self.model.set_combine_pedals(1)
+        self.ui.set_pedal_levels()
 
     def on_combine_clutch_clicked(self, widget):
         self.model.set_combine_pedals(2)
+        self.ui.set_pedal_levels()
 
     def on_ff_gain_value_changed(self, widget):
         ff_gain = int(widget.get_value())
@@ -286,3 +289,8 @@ class GtkHandlers:
 
     def on_start_app_clicked(self, widget):
         self.controller.start_app()
+
+    def on_pedal_mode_changed(self, widget):
+        mode = self.ui.pedal_mode_combobox.get_active()
+        self.model.set_pedal_mode(mode)
+        self.model.flush_ui()

--- a/oversteer/gtk_handlers.py
+++ b/oversteer/gtk_handlers.py
@@ -4,6 +4,7 @@ import threading
 import traceback
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
+from .pedal_mode import CombinedPedals
 
 class GtkHandlers:
 
@@ -81,15 +82,15 @@ class GtkHandlers:
         self.ui.overlay_wheel_range.set_label(str(wrange))
 
     def on_combine_none_clicked(self, widget):
-        self.model.set_combine_pedals(0)
+        self.model.set_combine_pedals(CombinedPedals.NONE)
         self.ui.set_pedal_levels()
 
     def on_combine_brakes_clicked(self, widget):
-        self.model.set_combine_pedals(1)
+        self.model.set_combine_pedals(CombinedPedals.COMBINE_BRAKES)
         self.ui.set_pedal_levels()
 
     def on_combine_clutch_clicked(self, widget):
-        self.model.set_combine_pedals(2)
+        self.model.set_combine_pedals(CombinedPedals.COMBINE_CLUTCH)
         self.ui.set_pedal_levels()
 
     def on_ff_gain_value_changed(self, widget):

--- a/oversteer/gtk_ui.py
+++ b/oversteer/gtk_ui.py
@@ -324,9 +324,9 @@ class GtkUi:
         else:
             self.combine_brakes.set_sensitive(True)
             self.combine_clutch.set_sensitive(True)
-        if combine_pedals == 1:
+        if combine_pedals == pedal_mode.CombinedPedals.COMBINE_BRAKES:
             self.combine_brakes.set_active(True)
-        elif combine_pedals == 2:
+        elif combine_pedals == pedal_mode.CombinedPedals.COMBINE_CLUTCH:
             self.combine_clutch.set_active(True)
         else:
             self.combine_none.set_active(True)

--- a/oversteer/gtk_ui.py
+++ b/oversteer/gtk_ui.py
@@ -5,6 +5,7 @@ import os
 from .gtk_handlers import GtkHandlers
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib
+from . import pedal_mode
 
 class GtkUi:
 
@@ -46,6 +47,11 @@ class GtkUi:
         self.emulation_mode_combobox.pack_start(cell_renderer, True)
         self.emulation_mode_combobox.add_attribute(cell_renderer, 'text', 1)
         self.emulation_mode_combobox.set_id_column(0)
+
+        cell_renderer = Gtk.CellRendererText()
+        self.pedal_mode_combobox.pack_start(cell_renderer, True)
+        self.pedal_mode_combobox.add_attribute(cell_renderer, 'text', 1)
+        self.pedal_mode_combobox.set_id_column(0)
 
         self.set_range_overlay('never')
         self.disable_save_profile()
@@ -255,6 +261,47 @@ class GtkUi:
             self.emulation_mode_combobox.set_sensitive(True)
             self.change_emulation_mode_button.set_sensitive(True)
             self.emulation_mode_combobox.set_active_id(mode)
+
+    def set_pedal_modes(self):
+        model = self.pedal_mode_combobox.get_model()
+        if model is None:
+            model = Gtk.ListStore(int, str)
+
+        for mode in pedal_mode.AxisMode:
+            model.append(mode.value)
+        self.pedal_mode_combobox.set_model(model)
+        self.set_pedal_mode(pedal_mode.AxisMode.NORMAL.value.id)
+
+    def set_pedal_mode(self, mode):
+        if self.pedal_mode_combobox.get_model() is None:
+            return
+
+        set_mode = list(pedal_mode.AxisMode)[mode]
+        self.pedal_mode_combobox.set_active(set_mode.value.id)
+        self.set_pedal_levels()
+
+    def set_pedal_levels(self):
+        combine_mode = self.controller.device.get_combine_pedals()
+        axis_mode = self.controller.device.get_pedal_mode()
+
+        acceleration_out = pedal_mode.get_modified_value(axis_mode, 255)
+        acceleration_in = pedal_mode.get_modified_value(axis_mode, 0)
+        brakes_out = pedal_mode.get_modified_value(axis_mode, 255)
+        clutch_out = pedal_mode.get_modified_value(axis_mode, 255)
+
+        accel = acceleration_out
+
+        if combine_mode == pedal_mode.CombinedPedals.COMBINE_BRAKES:
+            accel = acceleration_in + (acceleration_out - acceleration_in) / 2
+            brakes_out = 255
+        elif combine_mode == pedal_mode.CombinedPedals.COMBINE_CLUTCH:
+            accel = acceleration_in + (acceleration_out - acceleration_in) / 2
+            clutch_out = 255
+
+        self.safe_call(self.set_accelerator_input, int(accel))
+        self.safe_call(self.set_brakes_input, int(brakes_out))
+        self.safe_call(self.set_clutch_input, int(clutch_out))
+
 
     def set_range(self, wrange):
         if wrange is None:
@@ -611,6 +658,7 @@ class GtkUi:
         self.clutch_input = self.builder.get_object('clutch_input')
         self.accelerator_input = self.builder.get_object('accelerator_input')
         self.brakes_input = self.builder.get_object('brakes_input')
+        self.pedal_mode_combobox = self.builder.get_object('pedal_mode')
         self.hat_up_input = self.builder.get_object('hat_up_input')
         self.hat_down_input = self.builder.get_object('hat_down_input')
         self.hat_left_input = self.builder.get_object('hat_left_input')

--- a/oversteer/gui.py
+++ b/oversteer/gui.py
@@ -162,9 +162,13 @@ class Gui:
             profiles.append(profile_name)
         self.ui.set_profiles(profiles)
 
+    def populate_pedal_modes(self):
+        self.ui.set_pedal_modes()
+
     def populate_window(self):
         self.populate_devices()
         self.populate_profiles()
+        self.populate_pedal_modes()
 
     def change_device(self, device_id):
         self.device = self.device_manager.get_device(device_id)

--- a/oversteer/main.ui
+++ b/oversteer/main.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="autocenter_adjustment">
@@ -768,6 +768,19 @@
                                 <property name="position">1</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="opacity">0</property>
+                                <property name="orientation">vertical</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">True</property>
@@ -776,7 +789,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=3 n-rows=5 -->
                           <object class="GtkGrid">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -862,6 +875,48 @@
                               <packing>
                                 <property name="left-attach">2</property>
                                 <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-start">27</property>
+                                <property name="label" translatable="yes">Pedal mode</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">3</property>
+                                <property name="width">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="pedal_mode">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-text" translatable="yes">Change pedal axis behavior</property>
+                                <signal name="changed" handler="on_pedal_mode_changed" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">4</property>
+                                <property name="width">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-text" translatable="yes">The settings other than normal are only available by selecting the device called: "Custom pedal mode wheel" in-game. You may therefore need to rebind your keys in-game to use this feature.
+
+Oversteer must also be open while in-game in order for custom pedal modes to work</property>
+                                <property name="halign">start</property>
+                                <property name="stock">gtk-dialog-question</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">3</property>
                               </packing>
                             </child>
                           </object>
@@ -993,6 +1048,19 @@
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
                                 <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="opacity">0</property>
+                                <property name="orientation">vertical</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>

--- a/oversteer/model.py
+++ b/oversteer/model.py
@@ -18,6 +18,7 @@ class Model:
         'use_buttons': None,
         'center_wheel': None,
         'start_app_manually': None,
+        'pedal_mode': None,
     }
 
     types = {
@@ -35,6 +36,7 @@ class Model:
         'use_buttons': 'boolean',
         'center_wheel': 'boolean',
         'start_app_manually': 'boolean',
+        'pedal_mode': 'integer',
     }
 
     def __init__(self, device = None, ui = None):
@@ -78,6 +80,7 @@ class Model:
             'use_buttons': False if self.device.get_range() is not None else None,
             'center_wheel': False,
             'start_app_manually': False,
+            'pedal_mode': self.device.get_pedal_mode().value.id
         }
 
     def update_from_device_settings(self):
@@ -164,6 +167,14 @@ class Model:
 
     def get_mode(self):
         return self.data['mode']
+
+    def get_pedal_mode(self):
+        return self.data['pedal_mode']
+
+    def set_pedal_mode(self, value):
+        value = int(value)
+        if self.set_if_changed('pedal_mode', value):
+            self.device.set_pedal_mode(value)
 
     def set_range(self, value):
         value = int(value)
@@ -278,6 +289,8 @@ class Model:
             self.device.set_friction_level(self.data['friction_level'])
         if self.data['ffb_leds'] is not None:
             self.device.set_ffb_leds(self.data['ffb_leds'])
+        if self.data['pedal_mode'] is not None:
+            self.device.set_pedal_mode(self.data['pedal_mode'])
 
     def flush_ui(self, data = None):
         if data is None:
@@ -296,4 +309,6 @@ class Model:
         self.ui.set_use_buttons(data['use_buttons'])
         self.ui.set_center_wheel(data['center_wheel'])
         self.ui.set_start_app_manually(data['start_app_manually'])
+        self.ui.set_pedal_mode(data['pedal_mode'])
+        self.ui.set_pedal_levels()
 

--- a/oversteer/pedal_mode.py
+++ b/oversteer/pedal_mode.py
@@ -1,0 +1,69 @@
+from collections import namedtuple
+from enum import Enum
+
+
+ABS_mode = namedtuple("ABS_mode", ["id", "name"])
+
+
+class AxisMode(Enum):
+    NORMAL                      = ABS_mode(0, "Normal")
+    INVERTED                    = ABS_mode(1, "Inverted")
+    HALF                        = ABS_mode(2, "Half")
+    HALF_INVERTED               = ABS_mode(3, "Half inverted")
+    CENTERED_HALF               = ABS_mode(4, "Centered half")
+    CENTERED_HALF_INVERTED      = ABS_mode(5, "Centered half inverted")
+    CENTERED_SWITCHING          = ABS_mode(6, "Centered switching")
+    CENTERED_SWITCHING_INVERTED = ABS_mode(7, "Centered switching inverted")
+    CENTERED_LOOPING            = ABS_mode(8, "Centered looping")
+    CENTERED_LOOPING_INVERTED   = ABS_mode(9, "Centered looping inverted")
+
+
+class CombinedPedals:
+    NONE = 0
+    COMBINE_BRAKES = 1
+    COMBINE_CLUTCH = 2
+
+
+def get_modified_value(mode, value):
+    if mode == AxisMode.NORMAL:
+        return value
+
+    elif mode == AxisMode.INVERTED:
+        return 255 - value
+
+    elif mode == AxisMode.HALF:
+        return value + int((255 - value + 1) / 2)
+
+    elif mode == AxisMode.HALF_INVERTED:
+        return (int(value / 2) - int(255 / 2)) * -1
+
+    elif mode == AxisMode.CENTERED_HALF:
+        return int(value / 2)
+
+    elif mode == AxisMode.CENTERED_HALF_INVERTED:
+        return 255 - int(value / 2)
+
+    elif mode == AxisMode.CENTERED_SWITCHING:
+        value = value - int(255 / 2) - 1
+        if value < 0:
+            value = (value * -1) + int(255 / 2)
+        return value
+
+    elif mode == AxisMode.CENTERED_SWITCHING_INVERTED:
+        if value > int(255 / 2):
+            value = int(255 + 255 / 2) - value + 1
+        return value
+
+    elif mode == AxisMode.CENTERED_LOOPING:
+        value = value - int(255 / 2) - 1
+        if value < 0:
+            value += 256
+        return value
+
+    elif mode == AxisMode.CENTERED_LOOPING_INVERTED:
+        value = int(255 / 2) - value
+        if value < 0:
+            value += 256
+        return value
+
+    return value


### PR DESCRIPTION
### Overview

This change allows users to change how their pedal axes behave, such as inverting the axes, making them start out centered etc.

This is useful in certain games where the axes are not treated properly, and there is no option to change it in-game, such as in Trackmania. Some of the modes might seem quite strange, but I added some of these with combined pedals in mind, even though I don't have much experience with flying games, so I don't know how useful they will be.

### Injector device

Ideally this should probably be done on an individual driver level, and I started by looking into doing this in new-lg4ff, but doing it in oversteer directly does allow us to create this functionality even for devices that do not have a built-in option for it. This should also allow us to do other things such as enable combined pedal support for devices with no option to combine pedals. In the future, checks could be implemented to see if the driver supports it natively, and if not, then we use the injector device method.

There are a couple of negatives to doing this in oversteer however:

1. It requires (to my knowledge) that we create a secondary "injector device" that we can inject events into. This means that there will be another device in-game that you have to select in order to use this feature (the device will not appear if using normal axis behavior however, so existing keybinds etc. should be unaffected)
2. Oversteer must be kept open while playing to make use of this new functionality, since the injector device lives in oversteer memory
3. This is a pretty minor point, but creating the injector device the first time you select something other than normal freezes the UI for about a second. Could maybe do the injector creation in a background task to prevent this though.

### Input needed

I created this PR as a draft as it is close, but not yet fully complete, and I require some input and guidance to put the last finishing touches on this:

1. **Devices with ranges other than 0-255**: This should be simple to implement, but I have no devices other than my G923 to test with. I was also a bit surprised at some of the devices and was wondering if I had misunderstood something; Is it really the case that ``wid.LG_WFG`` and ``wid.LG_WFFG`` only have 4 different values for their pedals for instance? (This is judging from what happens in device.py:normalize_event() )
2. **UI**: I am very much not a frontend guy, and I also use i3wm, so what looks fine for me might look really wacky for others. Would appreciate if you could take a look at the changes for this.
3. **argparse**: I have not created an option for setting the axis mode, but I could do that before finishing the PR
4. **test**: I have not taken a look at the testing framework at all. Should we implement some tests for this feature?

### Other stuff

Any refactoring, logic changes etc. that do not fall into any of the above categories are of course also welcome.

Thanks for reading my wall of text!