### PR TITLE
fix(udev): use new driver name

### DIFF
--- a/data/udev/99-thrustmaster-wheel-perms.rules
+++ b/data/udev/99-thrustmaster-wheel-perms.rules
@@ -9,12 +9,15 @@ ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b6
 
 # Thrustmaster T300RS Racing Wheel (USB)
 ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b66e", DRIVER=="tmff2", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
+ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b66e", DRIVER=="hid-tmff-new", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
 
 # Thrustmaster Ferrari F1 Wheel Advanced T300 (USB)
 ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b66f", DRIVER=="tmff2", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
+ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b66f", DRIVER=="hid-tmff-new", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
 
 # Thrustmaster T248 Racing Wheel (USB)
 ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b696", DRIVER=="tmff2", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level'"
+ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b696", DRIVER=="hid-tmff-new", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level'"
 
 # Thrustmaster T150 Racing Wheel (USB)
 ACTION=="bind", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b677", DRIVER=="hid-t150", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain autocenter'"


### PR DESCRIPTION
@Kumplul appears to have switched the upstream module name to hid-tmff-new[1].  So we now need to match the new name.  Have left the old name in place for now as it's possible people haven't updated and continue to use the previous module.

[1]: https://github.com/Kimplul/hid-tmff2/wiki#structure-of-the-thrustmaster-device-stack