### PR TITLE
Flatpak submission fixes

### DIFF
--- a/data/io.github.berarma.Oversteer.appdata.xml.in
+++ b/data/io.github.berarma.Oversteer.appdata.xml.in
@@ -34,6 +34,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
+      <caption>Home page</caption>
       <image>https://raw.githubusercontent.com/berarma/oversteer/master/data/oversteer-readme.png</image>
     </screenshot>
   </screenshots>
@@ -128,14 +129,14 @@
         </ul>
       </description>
     </release>
-    <release version="0.5.4" date="2021-01-03">
-      <description>
-        <p>Fix error on startup in some system configurations.</p>
-      </description>
-    </release>
     <release version="0.5.5" date="2020-09-17">
       <description>
         <p>Fix saving profile when the ffbmeter isn't supported.</p>
+      </description>
+    </release>
+    <release version="0.5.4" date="2021-01-03">
+      <description>
+        <p>Fix error on startup in some system configurations.</p>
       </description>
     </release>
     <release version="0.5.3" date="2020-09-06">


### PR DESCRIPTION
Fixed an error and a warning thrown by flatpak-builder by adding a caption to the screenshot and by fixing the version numbers in the metainfo file (0.5.5 was released before 0.5.4).