### PR TITLE
Fix thrustmaster udev driver key

### DIFF
--- a/data/udev/99-thrustmaster-wheel-perms.rules
+++ b/data/udev/99-thrustmaster-wheel-perms.rules
@@ -9,9 +9,9 @@ GOTO="end"
 
 LABEL="thrustmaster-rules"
 
-DRIVER="tmff2" GOTO="tmff-new"
-DRIVER="hid-tmff-new" GOTO="tmff-new"
-DRIVER="hid-t150" GOTO="t150"
+DRIVER=="tmff2" GOTO="tmff-new"
+DRIVER=="hid-tmff-new" GOTO="tmff-new"
+DRIVER=="hid-t150" GOTO="t150"
 DRIVER!="t500rs" GOTO="end"
 
 # Thrustmaster T500RS Racing Wheel (USB)


### PR DESCRIPTION
Fixes udev `DRIVER` rules key that is incorrectly using assignment `=` instead of comparison `==`, which causes the rule to not be evaluated correctly when attempting to test the rules with `udevadm test {device path}`:

```
/usr/local/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules:12 Invalid operator for DRIVER.
/usr/local/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules:13 Invalid operator for DRIVER.
/usr/local/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules:14 Invalid operator for DRIVER.
```