### PR TITLE
Adding support for Thrustmaster TS-PC

### DIFF
--- a/data/udev/99-thrustmaster-wheel-perms.rules
+++ b/data/udev/99-thrustmaster-wheel-perms.rules
@@ -36,6 +36,9 @@ ATTRS{idProduct}=="b696", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring
 # Thrustmaster TS-XW Racing Wheel (USB)
 ATTRS{idProduct}=="b692", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level'"
 
+# Thrustmaster TS-PC Racing Wheel (USB)
+ATTRS{idProduct}=="b689", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level'"
+
 GOTO="end"
 
 LABEL="t150"

--- a/oversteer/device_manager.py
+++ b/oversteer/device_manager.py
@@ -45,6 +45,7 @@ class DeviceManager:
             wid.TM_T80H: 240,
             wid.TM_TMX: 900,
             wid.TM_TSXW: 1080,
+            wid.TS_PC: 1080,
             wid.TM_TX: 900,
             wid.XX_FFBOARD: 1080,
         }

--- a/oversteer/wheel_ids.py
+++ b/oversteer/wheel_ids.py
@@ -40,5 +40,6 @@ TM_T80H = '044f:b66a'
 TM_TMX = '044f:b67f'
 TM_TX = '044f:b664'
 TM_TSXW = '044f:b692'
+TS_PC  = '044f:b65d'
 XX_FFBOARD = '1209:ffb0'
 

--- a/oversteer/wheel_ids.py
+++ b/oversteer/wheel_ids.py
@@ -40,6 +40,6 @@ TM_T80H = '044f:b66a'
 TM_TMX = '044f:b67f'
 TM_TX = '044f:b664'
 TM_TSXW = '044f:b692'
-TS_PC  = '044f:b65d'
+TS_PC  = '044f:b689'
 XX_FFBOARD = '1209:ffb0'
 


### PR DESCRIPTION
Hi!
Now that the `hid-tmff2` driver is supporting the TS-PC, I thought it would be nice to add it to oversteer.
I think I added it correctly (shows up just fine), also added udev rules.