### PR TITLE
Set center wheel on Thrustmaster T150

### DIFF
--- a/data/udev/99-thrustmaster-wheel-perms.rules
+++ b/data/udev/99-thrustmaster-wheel-perms.rules
@@ -44,7 +44,7 @@ GOTO="end"
 LABEL="t150"
 
 # Thrustmaster T150 Racing Wheel (USB)
-ATTRS{idProduct}=="b677", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain autocenter'"
+ATTRS{idProduct}=="b677", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain autocenter enable_autocenter'"
 
 # Thrustmaster TMX Racing Wheel (USB)
 ATTRS{idProduct}=="b67f", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain autocenter'"

--- a/oversteer/device.py
+++ b/oversteer/device.py
@@ -329,11 +329,21 @@ class Device:
             file.write(peak_ffb_level)
         return True
 
-    def center_wheel(self):
-        self.set_autocenter(100)
-        time.sleep(1)
-        self.set_autocenter(0)
-
+    def center_wheel(self, value):
+        if self.usb_id in [wid.TM_T150]:
+            path = self.checked_device_file("enable_autocenter")
+            if not path:
+                return False
+            v = 'n'
+            if value:
+                v = 'y'
+            with open(path, "w") as file:
+                file.write(v)
+        else:
+            self.set_autocenter(100)
+            time.sleep(1)
+            self.set_autocenter(0)
+ 
     def check_permissions(self):
         logging.debug("check_permissions: %s", self.dev_path)
         if not os.access(self.dev_path, os.F_OK | os.R_OK | os.X_OK):

--- a/oversteer/model.py
+++ b/oversteer/model.py
@@ -251,10 +251,10 @@ class Model:
     def get_use_buttons(self):
         return self.data['use_buttons']
 
-    def set_center_wheel(self, value):
+    def set_center_wheel(self, value=True):
         value = bool(value)
-        if self.set_if_changed('center_wheel', value) and value:
-            self.device.center_wheel()
+        if self.set_if_changed('center_wheel', value):
+            self.device.center_wheel(value)
 
     def set_start_app_manually(self, value):
         value = bool(value)


### PR DESCRIPTION
I guess centerl wheel as a tool might not make sense. so maybe this needs to be moved to other tab for Thrustmaster T150

- [x] configure option
- [ ] move tool into a config option
- [ ] read config on load

fixes #262 